### PR TITLE
Update 05-CoGAPS.Rmd

### DIFF
--- a/05-CoGAPS.Rmd
+++ b/05-CoGAPS.Rmd
@@ -45,7 +45,7 @@ ottrpal::set_knitr_image_path()
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; a. You should see RStudio.
 
-<img src="/cogaps-on-sciserver/resources/images/RStudio.png" alt="RStudio Screen">
+<img src="cogaps-on-sciserver/resources/images/RStudio.png" alt="RStudio Screen">
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; b. If you see something else, you may have picked the wrong "Compute Image" from the drop-down menu.
 
@@ -395,7 +395,7 @@ FeaturePlot(inputdata, pattern_names, cols=color_palette, reduction = "umap") & 
 
 6. Your output should look like this if the run was successful (visible in the bottom right corner of your screen):
 
-<img src="/cogaps-on-sciserver/resources/images/featureplotcogaps.png" alt="CoGAPS Feature Plot">
+<img src="cogaps-on-sciserver/resources/images/featureplotcogaps.png" alt="CoGAPS Feature Plot">
 
 ### Find Pattern Markers
 


### PR DESCRIPTION
Fix broken image paths

<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

#### What changes are being implemented in this Pull Request?



#### What was your approach?



#### What GitHub issue does your pull request address?



### Tell potential reviewers what kind of feedback you are soliciting.



### New Content Checklist

- [ ] New content/chapter is in an Rmd file with [this kind of format and headers](https://github.com/jhudsl/OTTR_Template/blob/main/02-chapter_of_course.Rmd).

- [ ] New content/chapter contains learning objectives.

- [ ] [Bookdown successfully re-renders and any new content files have been added to the _bookdown.yml](https://github.com/jhudsl/OTTR_Template/wiki/Publishing-with-Bookdown).

- [ ] [Spell check runs successfully](https://www.ottrproject.org/customize-robots.html#Spell_checking)).

- [ ] Any newly necessary packages that are needed have been added to the [Dockerfile and image](https://www.ottrproject.org/customize-docker.html).

- [ ] Images are in the [correct format for rendering](https://www.ottrproject.org/writing_content.html#set-up-images).

- [ ] Every new image has [alt text and is in a Google Slide](https://www.ottrproject.org/writing_content.html#Accessibility).

- [ ] Each slide is described in the notes of the slide so learners relying on a screen reader can access the content. See https://lastcallmedia.com/blog/accessible-comics for more guidance on this.

- [ ] The color palette choices of the slide are contrasted in a way that is friendly to those with color vision deficiencies.
You can check this using [Color Oracle](https://colororacle.org/).
